### PR TITLE
New post UI updates

### DIFF
--- a/feature/post/src/main/java/social/firefly/post/NewPostScreen.kt
+++ b/feature/post/src/main/java/social/firefly/post/NewPostScreen.kt
@@ -68,6 +68,7 @@ import social.firefly.core.ui.common.button.FfButton
 import social.firefly.core.ui.common.button.FfButtonContentPadding
 import social.firefly.core.ui.common.media.AttachmentMedia
 import social.firefly.core.ui.common.text.FfTextField
+import social.firefly.core.ui.common.text.FfTextFieldNoBorder
 import social.firefly.core.ui.common.text.SmallTextLabel
 import social.firefly.core.ui.common.transparentTextFieldColors
 import social.firefly.core.ui.common.utils.getWindowHeightClass
@@ -385,11 +386,11 @@ private fun MainBox(
 
                     item {
                         val highlightColor = FfTheme.colors.textLink
-                        FfTextField(
-                            modifier =
-                            Modifier
+                        FfTextFieldNoBorder(
+                            modifier = Modifier
                                 .fillMaxWidth()
-                                .focusRequester(textFieldFocusRequester),
+                                .focusRequester(textFieldFocusRequester)
+                                .padding(horizontal = 16.dp, vertical = 6.dp),
                             value = statusUiState.statusText,
                             onValueChange = { statusInteractions.onStatusTextUpdated(it) },
                             placeholder = {

--- a/feature/post/src/main/java/social/firefly/post/NewPostScreen.kt
+++ b/feature/post/src/main/java/social/firefly/post/NewPostScreen.kt
@@ -390,7 +390,7 @@ private fun MainBox(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .focusRequester(textFieldFocusRequester)
-                                .padding(horizontal = 16.dp, vertical = 6.dp),
+                                .padding(start = 16.dp, end = 16.dp, bottom = 6.dp),
                             value = statusUiState.statusText,
                             onValueChange = { statusInteractions.onStatusTextUpdated(it) },
                             placeholder = {
@@ -441,7 +441,7 @@ private fun MainBox(
 private fun InReplyToText(inReplyToAccountName: String?) {
     if (inReplyToAccountName != null) {
         Row(
-            modifier = Modifier.padding(start = 12.dp),
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 6.dp),
         ) {
             Icon(
                 modifier =
@@ -471,7 +471,7 @@ private fun ContentWarningEntry(
 ) {
     FfTextField(
         modifier = Modifier
-            .padding(horizontal = 16.dp)
+            .padding(start = 16.dp, end = 16.dp, bottom = 6.dp)
             .fillMaxWidth(),
         value = contentWarningText,
         onValueChange = { contentWarningInteractions.onContentWarningTextChanged(it) },

--- a/feature/post/src/main/java/social/firefly/post/NewPostScreen.kt
+++ b/feature/post/src/main/java/social/firefly/post/NewPostScreen.kt
@@ -290,21 +290,14 @@ private fun NewPostScreenContent(
 fun UserHeader(
     userHeaderState: UserHeaderState,
 ) {
-    Row {
-        AsyncImage(
-            modifier = Modifier
-                .padding(start = FfSpacing.sm)
-                .size(40.dp)
-                .clip(CircleShape)
-                .border(
-                    width = 3.dp,
-                    color = FfTheme.colors.layer1,
-                    shape = CircleShape,
-                ),
-            model = userHeaderState.avatarUrl,
-            contentDescription = null,
-        )
-    }
+    AsyncImage(
+        modifier = Modifier
+            .padding(start = FfSpacing.sm)
+            .size(40.dp)
+            .clip(CircleShape),
+        model = userHeaderState.avatarUrl,
+        contentDescription = null,
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -399,7 +392,7 @@ private fun MainBox(
                                 .focusRequester(textFieldFocusRequester),
                             value = statusUiState.statusText,
                             onValueChange = { statusInteractions.onStatusTextUpdated(it) },
-                            label = {
+                            placeholder = {
                                 Text(
                                     text = stringResource(id = R.string.new_post_text_field_label),
                                 )
@@ -476,9 +469,8 @@ private fun ContentWarningEntry(
     contentWarningInteractions: ContentWarningInteractions,
 ) {
     FfTextField(
-        modifier =
-        Modifier
-            .padding(16.dp)
+        modifier = Modifier
+            .padding(horizontal = 16.dp)
             .fillMaxWidth(),
         value = contentWarningText,
         onValueChange = { contentWarningInteractions.onContentWarningTextChanged(it) },

--- a/feature/post/src/main/res/values/strings.xml
+++ b/feature/post/src/main/res/values/strings.xml
@@ -26,7 +26,7 @@
     <string name="add_poll_option_button_content_description">add poll option</string>
     <string name="remove_poll_option_button_content_description">remove poll option</string>
 
-    <string name="new_post_text_field_label">What is on your mind?</string>
+    <string name="new_post_text_field_label">What\'s on your mind?</string>
 
     <string name="in_reply_to_account_name_label">In reply to %s</string>
 


### PR DESCRIPTION
- Removing the border from the avatar.  It was the same color as the background anyways, and was causing some pixelated issues
- Removed the label from the post text field and replaced it with a placeholder.  This will make it so `What's on your mind?` doesn't show up after typing, and it saves some vertical space.
- Made updates to the `FfTextField` that we use for the post body text field.
  - Removing the extra padding that comes with normal text fields
  - Setting the placeholder text color

![Screenshot_20240225_080754](https://github.com/Firefly-Social/Firefly/assets/14130581/31ab3e84-8bba-48f0-97e4-9592ebdc4178)

![Screenshot_20240225_080859](https://github.com/Firefly-Social/Firefly/assets/14130581/c5f940cd-ab6a-481c-b41a-f574ae21a15b)

