### PR TITLE
fixing deprecated functionality

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ jobs:
       - id: should_run
         continue-on-error: true
         name: check latest commit is less than a day old
-        run: test -z $(git rev-list --after="24 hours" ${{ github.sha }}) && echo "::set-output name=should_run::false"
+        run: test -z $(git rev-list --after="24 hours" ${{ github.sha }}) && echo "should_run=false" >> "$GITHUB_OUTPUT"
 
   release:
     needs: check_date


### PR DESCRIPTION
Updating deprecated action functionality 
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/